### PR TITLE
Replace deprecated sass color functions for new channel function.

### DIFF
--- a/apca.scss
+++ b/apca.scss
@@ -30,9 +30,9 @@ $_greenMultiplier: 0.7151522;
 $_blueMultiplier: 0.072175;
 
 @function _luminance($color) {
-  $red: color.red($color);
-  $green: color.green($color);
-  $blue: color.blue($color);
+  $red: color.channel($color, "red", $space: rgb);
+  $green: color.channel($color, "green", $space: rgb);
+  $blue: color.channel($color, "blue", $space: rgb);
 
   $redLuminance: math.pow(math.div($red, 255), $_Strc) * $_redMultiplier;
   $greenLuminance: math.pow(math.div($green, 255), $_Strc) * $_greenMultiplier;
@@ -69,7 +69,7 @@ $_blueMultiplier: 0.072175;
  * @param   {color}  $textColor        Text color
  * @param   {color}  $backgroundColor  Background color
  *
- * @return  {number}                    A number between -108 and 107 representing the lightness contrast 
+ * @return  {number}                    A number between -108 and 107 representing the lightness contrast
  */
 @function contrast($textColor, $backgroundColor) {
   @if (meta.type-of($textColor) != 'color') {
@@ -113,7 +113,7 @@ $_blueMultiplier: 0.072175;
   @if (meta.type-of($backgroundColor) != 'color') {
     @error "Type Error: apca.recommend-text-color expects a color as third argument but received #{meta.type-of($darkColor)}. Please provide a valid color.";
   }
-  
+
   $lightContrast: math.abs(contrast($lightColor, $backgroundColor));
   $darkContrast: math.abs(contrast($darkColor, $backgroundColor));
   $contrastColor: null;


### PR DESCRIPTION
The SASS functions `color.red`, `color.green` and `color.blue` are deprecated since 1.79.0.
These functions should be replaced with the `color.channel` function.

More info: https://sass-lang.com/documentation/breaking-changes/color-functions/