### PR TITLE
Make warning threshold configurable

### DIFF
--- a/apca.scss
+++ b/apca.scss
@@ -10,6 +10,24 @@
 //
 // -------------------
 
+/**
+ * Configuration: Warning Threshold
+ *
+ * Defines the APCA contrast level below which the library will output warnings.
+ * The default is 90, which is the preferred level for fluent body text.
+ *
+ * To disable all warnings, set this value to 0.
+ * To only receive warnings for critical contrast issues, set this to a lower value (e.g., 30 or 45).
+ *
+ * @example
+ * ```
+ *   @use "sass-apca" with (
+ *     $warning-threshold: 0
+ *   );
+ * ```
+ */
+$warning-threshold: 90 !default;
+
 // Powercurve exponents
 $_Strc: 2.4;
 $_Ntx: 0.57;
@@ -127,18 +145,20 @@ $_blueMultiplier: 0.072175;
     $bestContrast: $lightContrast
   }
 
-  @if ($bestContrast < 15) {
-    @warn "Your best contrast is #{$bestContrast}. This is lower than 15, the absolute minimum for any non-text that needs to be discernible and differentiable, and is no less than 6px in its smallest dimension. This may include disabled large buttons. Designers should treat anything below this level as invisible, as it will not be visible for many users. This minimum level should be avoided for any items important to the use, understanding, or interaction of the site.";
-  } @else if ($bestContrast < 30) {
-    @warn "Your best contrast is #{$bestContrast}. This is lower than 30, the absolute minimum for any text not listed above. This includes placeholder text and disabled element text. This is also the minimum for large/solid semantic & understandable non-text elements.";
-  } @else if ($bestContrast < 45) {
-    @warn "Your best contrast is #{$bestContrast}. This is lower than 45, the minimum for larger, heavier text (36px normal weight or 24px bold) such as headlines. This is also the minimum for pictograms with fine details.";
-  } @else if ($bestContrast < 60) {
-    @warn "Your best contrast is #{$bestContrast}. This is lower than 60, the minimum level recommended for content text that is not body, column, or block text. In other words, text you want people to read. The minimums: 24px normal weight (400) or 16px/700 (bold). These values based on the reference font Helvetica.";
-  } @else if ($bestContrast < 75) {
-    @warn "Your best contrast is #{$bestContrast}. This is lower than 75, the minimum level for columns of body text with a font no smaller than 18px/400. Lc 75 should be considered a minimum for text where readability is important.";
-  } @else if ($bestContrast < 90) {
-    @warn "Your best contrast is #{$bestContrast}. This is lower than 90, the preferred level for fluent text and columns of body text with a font no smaller than 14px/weight 400 (normal).";
+  @if ($bestContrast < $warning-threshold) {
+    @if ($bestContrast < 15) {
+      @warn "Your best contrast is #{$bestContrast}. This is lower than 15, the absolute minimum for any non-text that needs to be discernible and differentiable, and is no less than 6px in its smallest dimension. This may include disabled large buttons. Designers should treat anything below this level as invisible, as it will not be visible for many users. This minimum level should be avoided for any items important to the use, understanding, or interaction of the site.";
+    } @else if ($bestContrast < 30) {
+      @warn "Your best contrast is #{$bestContrast}. This is lower than 30, the absolute minimum for any text not listed above. This includes placeholder text and disabled element text. This is also the minimum for large/solid semantic & understandable non-text elements.";
+    } @else if ($bestContrast < 45) {
+      @warn "Your best contrast is #{$bestContrast}. This is lower than 45, the minimum for larger, heavier text (36px normal weight or 24px bold) such as headlines. This is also the minimum for pictograms with fine details.";
+    } @else if ($bestContrast < 60) {
+      @warn "Your best contrast is #{$bestContrast}. This is lower than 60, the minimum level recommended for content text that is not body, column, or block text. In other words, text you want people to read. The minimums: 24px normal weight (400) or 16px/700 (bold). These values based on the reference font Helvetica.";
+    } @else if ($bestContrast < 75) {
+      @warn "Your best contrast is #{$bestContrast}. This is lower than 75, the minimum level for columns of body text with a font no smaller than 18px/400. Lc 75 should be considered a minimum for text where readability is important.";
+    } @else if ($bestContrast < 90) {
+      @warn "Your best contrast is #{$bestContrast}. This is lower than 90, the preferred level for fluent text and columns of body text with a font no smaller than 14px/weight 400 (normal).";
+    }
   }
 
   @return $contrastColor;


### PR DESCRIPTION
### Summary
Currently, the module outputs warnings for any contrast score below 90. While helpful, this can generate a significant amount of noise in console logs for projects that are aware of these contrast levels or wish to enforce a different standard (e.g., only warn below 45).

This PR introduces a configurable `$warning-threshold` variable.

### Changes
- Added `$warning-threshold: 90 !default;` at the top of the file.
- Wrapped the existing warning logic in the `recommend-text-color` function to check against this threshold before logging.
- Default behavior remains unchanged (threshold is set to 90).

## How to test / Usage 
Users can now control the verbosity when loading the module.

To *disable all warnings*:
```scss
@use "sass-apca/apca" with (
  $warning-threshold: 0
);
```

To *only warn for critical issues* (e.g., lower than 45):
```scss
@use "sass-apca/apca" with (
  $warning-threshold: 45
);
```